### PR TITLE
fix: Optimize editor toolbar layout for mobile screens

### DIFF
--- a/src/routes/admin/WritePage.tsx
+++ b/src/routes/admin/WritePage.tsx
@@ -209,6 +209,18 @@ export default function WritePage() {
     }
   };
 
+  const toolbarItems = isDesktop
+    ? [
+        ["heading", "bold", "italic"],
+        ["hr"],
+        ["image", "link"],
+        ["ul", "ol"],
+        ["code", "codeblock"],
+        ["table", "strike"],
+        ["quote"],
+      ]
+    : [["heading", "bold"], ["image", "link"], ["ul", "ol"], ["code"]];
+
   return (
     <main className="flex flex-1 flex-col">
       {/* 헤더 영역 */}
@@ -322,14 +334,7 @@ export default function WritePage() {
           hooks={{
             addImageBlobHook: handleImageUpload,
           }}
-          toolbarItems={[
-            ["heading", "bold", "italic"],
-            ["hr"],
-            ["image", "link"],
-            ["ul", "ol"],
-            ["code", "codeblock"],
-            ...(isDesktop ? [["table", "strike"], ["quote"]] : []),
-          ]}
+          toolbarItems={toolbarItems}
         />
       </div>
 


### PR DESCRIPTION
- 모바일에서 글쓰기 에디터 모드일 때, 툴바가 너무 많아 화면을 가리는 이슈 수정
  - 모바일에서는 heading, bold, image, link, ul, ol, code 등 핵심 기능만 남겨두어 툴바가 잘리지 않도록 조정
  - 툴바 아이템을 별도의 변수로 분리
<img width="373" alt="스크린샷 2025-01-09 오후 9 36 58" src="https://github.com/user-attachments/assets/e42cb922-1f1e-4544-b570-9fe13ec5dc2a" />
