### PR TITLE
메인 페이지 데이터 페칭, 공통 스켈레톤 컴포넌트 적용 등

### DIFF
--- a/src/components/common/PostCardSkeleton.tsx
+++ b/src/components/common/PostCardSkeleton.tsx
@@ -1,0 +1,39 @@
+import { Card, CardContent } from "../ui/card";
+import { Skeleton } from "../ui/skeleton";
+
+interface PostCardSkeletonProps {
+  title: string;
+  count?: number;
+}
+
+export default function PostCardSkeleton({
+  title,
+  count = 6,
+}: PostCardSkeletonProps) {
+  return (
+    <section>
+      <h2 className="mb-6 text-2xl font-bold tracking-tight">{title}</h2>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: count }).map((_, index) => (
+          <Card key={index} className="overflow-hidden">
+            <CardContent className="p-0">
+              <div className="flex flex-col">
+                <Skeleton className="aspect-[16/10]" />
+                <div className="flex flex-col space-y-4 p-6">
+                  <Skeleton className="h-6 w-24" />
+                  <Skeleton className="h-8 w-full" />
+                  <Skeleton className="h-20 w-full" />
+                  <div className="flex gap-3">
+                    <Skeleton className="h-4 w-16" />
+                    <Skeleton className="h-4 w-16" />
+                    <Skeleton className="ml-auto h-4 w-24" />
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/PopularPosts.tsx
+++ b/src/components/home/PopularPosts.tsx
@@ -1,4 +1,3 @@
-import { Post, Category } from "@/types";
 import {
   Carousel,
   CarouselContent,
@@ -8,13 +7,20 @@ import {
 } from "@/components/ui/carousel";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import PostCardSkeleton from "../common/PostCardSkeleton";
+import { stripHtmlTags } from "@/utils";
+import { Post } from "@/types";
 
 interface PopularPostsProps {
   posts: Post[];
-  categories: Category[];
+  isLoading: boolean;
 }
 
-export function PopularPosts({ posts, categories }: PopularPostsProps) {
+export function PopularPosts({ posts, isLoading }: PopularPostsProps) {
+  if (isLoading) {
+    return <PostCardSkeleton title="인기 게시글" count={3} />;
+  }
+
   return (
     <section className="relative">
       <h2 className="mb-6 text-2xl font-bold tracking-tight">인기 게시글</h2>
@@ -31,9 +37,17 @@ export function PopularPosts({ posts, categories }: PopularPostsProps) {
               />
             </div>
             <div className="flex min-w-0 flex-1 flex-col">
-              <Badge variant="outline" className="mb-1 w-fit">
-                {categories.find((c) => c.id === post.categoryId)?.name}
-              </Badge>
+              <div className="mb-1 flex flex-wrap gap-1">
+                {post.tags?.length ? (
+                  post.tags.map((tag) => (
+                    <Badge key={tag} variant="outline">
+                      {tag}
+                    </Badge>
+                  ))
+                ) : (
+                  <Badge variant="outline">태그없음</Badge>
+                )}
+              </div>
               <h3 className="mb-auto line-clamp-2 text-base font-semibold">
                 {post.title}
               </h3>
@@ -98,14 +112,22 @@ export function PopularPosts({ posts, categories }: PopularPostsProps) {
                       />
                     </div>
                     <CardContent className="flex flex-1 flex-col p-4">
-                      <Badge variant="outline" className="mb-2 w-fit">
-                        {categories.find((c) => c.id === post.categoryId)?.name}
-                      </Badge>
+                      <div className="mb-2 flex flex-wrap gap-1">
+                        {post.tags?.length ? (
+                          post.tags.map((tag) => (
+                            <Badge key={tag} variant="outline">
+                              {tag}
+                            </Badge>
+                          ))
+                        ) : (
+                          <Badge variant="outline">태그없음</Badge>
+                        )}
+                      </div>
                       <h3 className="mb-2 line-clamp-2 text-lg font-semibold">
                         {post.title}
                       </h3>
                       <p className="mb-auto line-clamp-2 text-sm text-muted-foreground">
-                        {post.excerpt}
+                        {stripHtmlTags(post.excerpt)}
                       </p>
                       <div className="mt-4 flex items-center gap-3 text-sm text-muted-foreground">
                         <span className="flex items-center gap-1">

--- a/src/components/home/PopularPosts.tsx
+++ b/src/components/home/PopularPosts.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import {
   Carousel,
   CarouselContent,
@@ -28,7 +29,11 @@ export function PopularPosts({ posts, isLoading }: PopularPostsProps) {
       {/* 모바일 뷰 */}
       <div className="divide-y divide-border md:hidden">
         {posts.map((post) => (
-          <div key={post.id} className="flex gap-4 py-4 first:pt-0 last:pb-0">
+          <Link
+            key={post.id}
+            to={`/posts/${post.id}`}
+            className="flex gap-4 py-4 transition-colors first:pt-0 last:pb-0 hover:bg-muted/50"
+          >
             <div className="h-24 w-24 flex-shrink-0 overflow-hidden rounded-md">
               <img
                 src={post.thumbnailUrl}
@@ -89,7 +94,7 @@ export function PopularPosts({ posts, isLoading }: PopularPostsProps) {
                 </time>
               </div>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
 
@@ -102,75 +107,77 @@ export function PopularPosts({ posts, isLoading }: PopularPostsProps) {
                 key={post.id}
                 className="pl-2 md:basis-1/2 md:pl-4 lg:basis-1/3"
               >
-                <Card className="h-full overflow-hidden">
-                  <div className="flex h-full flex-col">
-                    <div className="aspect-[16/10] overflow-hidden">
-                      <img
-                        src={post.thumbnailUrl}
-                        alt=""
-                        className="h-full w-full rounded-t-lg object-cover transition-transform duration-300 hover:scale-105"
-                      />
+                <Link to={`/posts/${post.id}`}>
+                  <Card className="h-full overflow-hidden transition-colors hover:bg-muted/50">
+                    <div className="flex h-full flex-col">
+                      <div className="aspect-[16/10] overflow-hidden">
+                        <img
+                          src={post.thumbnailUrl}
+                          alt=""
+                          className="h-full w-full rounded-t-lg object-cover transition-transform duration-300 hover:scale-105"
+                        />
+                      </div>
+                      <CardContent className="flex flex-1 flex-col p-4">
+                        <div className="mb-2 flex flex-wrap gap-1">
+                          {post.tags?.length ? (
+                            post.tags.map((tag) => (
+                              <Badge key={tag} variant="outline">
+                                {tag}
+                              </Badge>
+                            ))
+                          ) : (
+                            <Badge variant="outline">태그없음</Badge>
+                          )}
+                        </div>
+                        <h3 className="mb-2 line-clamp-2 text-lg font-semibold">
+                          {post.title}
+                        </h3>
+                        <p className="mb-auto line-clamp-2 text-sm text-muted-foreground">
+                          {stripHtmlTags(post.excerpt)}
+                        </p>
+                        <div className="mt-4 flex items-center gap-3 text-sm text-muted-foreground">
+                          <span className="flex items-center gap-1">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-4 w-4"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                            >
+                              <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
+                              <circle cx="12" cy="12" r="3" />
+                            </svg>
+                            {post.viewCount}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              className="h-4 w-4"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                            >
+                              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+                            </svg>
+                            {post.likeCount}
+                          </span>
+                          <time
+                            dateTime={new Date(
+                              post.createdAt.seconds * 1000,
+                            ).toISOString()}
+                            className="ml-auto"
+                          >
+                            {new Date(
+                              post.createdAt.seconds * 1000,
+                            ).toLocaleDateString()}
+                          </time>
+                        </div>
+                      </CardContent>
                     </div>
-                    <CardContent className="flex flex-1 flex-col p-4">
-                      <div className="mb-2 flex flex-wrap gap-1">
-                        {post.tags?.length ? (
-                          post.tags.map((tag) => (
-                            <Badge key={tag} variant="outline">
-                              {tag}
-                            </Badge>
-                          ))
-                        ) : (
-                          <Badge variant="outline">태그없음</Badge>
-                        )}
-                      </div>
-                      <h3 className="mb-2 line-clamp-2 text-lg font-semibold">
-                        {post.title}
-                      </h3>
-                      <p className="mb-auto line-clamp-2 text-sm text-muted-foreground">
-                        {stripHtmlTags(post.excerpt)}
-                      </p>
-                      <div className="mt-4 flex items-center gap-3 text-sm text-muted-foreground">
-                        <span className="flex items-center gap-1">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            className="h-4 w-4"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          >
-                            <path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" />
-                            <circle cx="12" cy="12" r="3" />
-                          </svg>
-                          {post.viewCount}
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            className="h-4 w-4"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                          >
-                            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-                          </svg>
-                          {post.likeCount}
-                        </span>
-                        <time
-                          dateTime={new Date(
-                            post.createdAt.seconds * 1000,
-                          ).toISOString()}
-                          className="ml-auto"
-                        >
-                          {new Date(
-                            post.createdAt.seconds * 1000,
-                          ).toLocaleDateString()}
-                        </time>
-                      </div>
-                    </CardContent>
-                  </div>
-                </Card>
+                  </Card>
+                </Link>
               </CarouselItem>
             ))}
           </CarouselContent>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,31 @@
+export function stripHtmlTags(html: string) {
+  if (!html) return "";
+
+  const withoutImages = html.replace(
+    /<img[^>]*>|<img.*?\/?>|\s*<img[^>]*src="[^"]*"[^>]*>/g,
+    "",
+  );
+
+  const withoutFirebaseUrls = withoutImages.replace(
+    /<img src="https:\/\/firebasestorage\.googleapis\.com[^"]*"[^>]*>/g,
+    "",
+  );
+
+  const withoutPlainTextUrls = withoutFirebaseUrls.replace(
+    /<img src="https:\/\/firebasestorage\.googleapis\.com[^"]*"/g,
+    "",
+  );
+
+  const withoutUrls = withoutPlainTextUrls
+    .replace(
+      /<img src="https:\/\/firebasestorage\.googleapis\.com.*?(?=")/g,
+      "",
+    )
+    .replace(/https:\/\/firebasestorage\.googleapis\.com[^\s]*/g, "")
+    .replace(/<img src="/g, "");
+
+  const withoutTags = withoutUrls.replace(/<[^>]*>/g, "");
+  const decoded = withoutTags.replace(/&[^;]+;/g, " ");
+
+  return decoded.replace(/\s+/g, " ").trim();
+}


### PR DESCRIPTION
- 메인 HomePage 컴포넌트에서 데이터 페칭
  - PopularPosts, RecentPosts 에 데이터 props 로 전달
 
- 데이터가 로딩중일 때 보여줄 PostCardSkeleton 공통 컴포넌트 작성
  - 추가 count prop 으로 보여줄 skeleton 의 갯수 지정 가능

- PopularPosts 의 항목별 link post 상세 페이지 경로 이동
- 공통 함수 별도의 유틸 파일에 저장