### PR TITLE
게시글 목록 페이지 UI 구현

### DIFF
--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { ButtonProps, buttonVariants } from "@/components/ui/button"
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+)
+Pagination.displayName = "Pagination"
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = "PaginationContent"
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+))
+PaginationItem.displayName = "PaginationItem"
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<"a">
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = "PaginationLink"
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = "PaginationPrevious"
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = "PaginationNext"
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = "PaginationEllipsis"
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/routes/posts/PostsPage.tsx
+++ b/src/routes/posts/PostsPage.tsx
@@ -71,12 +71,22 @@ export default function Posts() {
           <TableHeader>
             <TableRow>
               <TableHead>제목</TableHead>
-              <TableHead>요약</TableHead>
-              <TableHead className="w-[100px]">카테고리</TableHead>
-              <TableHead className="w-[150px]">작성자</TableHead>
-              <TableHead className="w-[150px]">작성일</TableHead>
-              <TableHead className="w-[150px]">업데이트일</TableHead>
-              <TableHead className="w-[100px] text-right">조회</TableHead>
+              <TableHead className="hidden md:table-cell">요약</TableHead>
+              <TableHead className="hidden w-[100px] sm:table-cell">
+                카테고리
+              </TableHead>
+              <TableHead className="hidden w-[150px] lg:table-cell">
+                작성자
+              </TableHead>
+              <TableHead className="hidden w-[150px] lg:table-cell">
+                작성일
+              </TableHead>
+              <TableHead className="hidden w-[150px] xl:table-cell">
+                업데이트일
+              </TableHead>
+              <TableHead className="hidden w-[100px] text-right sm:table-cell">
+                조회
+              </TableHead>
               <TableHead className="w-[100px] text-right">좋아요</TableHead>
             </TableRow>
           </TableHeader>
@@ -90,8 +100,14 @@ export default function Posts() {
                 <TableCell>
                   <div>
                     <span className="font-medium">{post.title}</span>
+                    <div className="mt-1 text-sm text-muted-foreground md:hidden">
+                      {post.excerpt}
+                    </div>
+                    <div className="mt-1 text-sm text-muted-foreground lg:hidden">
+                      {post.author} · {post.createdAt}
+                    </div>
                     {post.tags.length > 0 && (
-                      <div className="mt-1 flex gap-1">
+                      <div className="mt-1 flex flex-wrap gap-1">
                         {post.tags.map((tag) => (
                           <span
                             key={tag}
@@ -104,18 +120,26 @@ export default function Posts() {
                     )}
                   </div>
                 </TableCell>
-                <TableCell className="text-sm text-muted-foreground">
+                <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
                   {post.excerpt}
                 </TableCell>
-                <TableCell>
+                <TableCell className="hidden sm:table-cell">
                   <span className="rounded-lg bg-primary/10 px-2 py-1 text-sm text-primary">
                     {post.category}
                   </span>
                 </TableCell>
-                <TableCell>{post.author}</TableCell>
-                <TableCell>{post.createdAt}</TableCell>
-                <TableCell>{post.updatedAt}</TableCell>
-                <TableCell className="text-right">{post.viewCount}</TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  {post.author}
+                </TableCell>
+                <TableCell className="hidden lg:table-cell">
+                  {post.createdAt}
+                </TableCell>
+                <TableCell className="hidden xl:table-cell">
+                  {post.updatedAt}
+                </TableCell>
+                <TableCell className="hidden text-right sm:table-cell">
+                  {post.viewCount}
+                </TableCell>
                 <TableCell className="text-right">{post.likeCount}</TableCell>
               </TableRow>
             ))}

--- a/src/routes/posts/PostsPage.tsx
+++ b/src/routes/posts/PostsPage.tsx
@@ -1,7 +1,166 @@
-export default function PostsPage() {
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface Post {
+  id: number;
+  title: string;
+  author: string;
+  createdAt: string;
+  updatedAt: string;
+  viewCount: number;
+  likeCount: number;
+  categoryId: number;
+  category: string;
+  tags: string[];
+  excerpt: string;
+}
+
+const DUMMY_POSTS: Post[] = Array.from({ length: 23 }, (_, i) => ({
+  id: i + 1,
+  title: `게시글 제목 ${i + 1}`,
+  author: `작성자 ${i + 1}`,
+  createdAt: new Date(2024, 0, i + 1).toLocaleDateString(),
+  updatedAt: new Date(2024, 0, i + 2).toLocaleDateString(),
+  viewCount: Math.floor(Math.random() * 100),
+  likeCount: Math.floor(Math.random() * 50),
+  categoryId: Math.floor(Math.random() * 3) + 1,
+  category: ["개발", "AI", "일상"][Math.floor(Math.random() * 3)],
+  tags: ["React", "TypeScript", "JavaScript"].slice(
+    0,
+    Math.floor(Math.random() * 3) + 1,
+  ),
+  excerpt: `이것은 게시글 ${i + 1}의 요약입니다.`,
+}));
+
+export default function Posts() {
+  const [currentPage, setCurrentPage] = useState(1);
+  const navigate = useNavigate();
+  const postsPerPage = 10;
+
+  const indexOfLastPost = currentPage * postsPerPage;
+  const indexOfFirstPost = indexOfLastPost - postsPerPage;
+  const currentPosts = DUMMY_POSTS.slice(indexOfFirstPost, indexOfLastPost);
+  const totalPages = Math.ceil(DUMMY_POSTS.length / postsPerPage);
+
+  const handleRowClick = (postId: number) => {
+    navigate(`/posts/${postId}`);
+  };
+
   return (
     <div className="container py-8">
-      <h1 className="text-3xl font-bold">블로그 목록</h1>
+      <h1 className="mb-8 text-3xl font-bold">게시글 목록</h1>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>제목</TableHead>
+              <TableHead>요약</TableHead>
+              <TableHead className="w-[100px]">카테고리</TableHead>
+              <TableHead className="w-[150px]">작성자</TableHead>
+              <TableHead className="w-[150px]">작성일</TableHead>
+              <TableHead className="w-[150px]">업데이트일</TableHead>
+              <TableHead className="w-[100px] text-right">조회</TableHead>
+              <TableHead className="w-[100px] text-right">좋아요</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {currentPosts.map((post) => (
+              <TableRow
+                key={post.id}
+                className="cursor-pointer hover:bg-muted/50"
+                onClick={() => handleRowClick(post.id)}
+              >
+                <TableCell>
+                  <div>
+                    <span className="font-medium">{post.title}</span>
+                    {post.tags.length > 0 && (
+                      <div className="mt-1 flex gap-1">
+                        {post.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell className="text-sm text-muted-foreground">
+                  {post.excerpt}
+                </TableCell>
+                <TableCell>
+                  <span className="rounded-lg bg-primary/10 px-2 py-1 text-sm text-primary">
+                    {post.category}
+                  </span>
+                </TableCell>
+                <TableCell>{post.author}</TableCell>
+                <TableCell>{post.createdAt}</TableCell>
+                <TableCell>{post.updatedAt}</TableCell>
+                <TableCell className="text-right">{post.viewCount}</TableCell>
+                <TableCell className="text-right">{post.likeCount}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="mt-4">
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (currentPage > 1) setCurrentPage(currentPage - 1);
+                }}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }, (_, i) => (
+              <PaginationItem key={i + 1}>
+                <PaginationLink
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setCurrentPage(i + 1);
+                  }}
+                  isActive={currentPage === i + 1}
+                >
+                  {i + 1}
+                </PaginationLink>
+              </PaginationItem>
+            ))}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (currentPage < totalPages) setCurrentPage(currentPage + 1);
+                }}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
     </div>
   );
 }

--- a/src/routes/posts/PostsPage.tsx
+++ b/src/routes/posts/PostsPage.tsx
@@ -66,31 +66,34 @@ export default function Posts() {
   };
 
   return (
-    <div className="container py-8">
+    <div className="container">
       <h1 className="mb-8 text-3xl font-bold">게시글 목록</h1>
-
       <div className="rounded-md border">
         <Table>
           <TableHeader>
-            <TableRow>
-              <TableHead>제목</TableHead>
-              <TableHead className="hidden md:table-cell">요약</TableHead>
-              <TableHead className="hidden w-[100px] sm:table-cell">
+            <TableRow className="bg-muted/50 hover:bg-muted/50">
+              <TableHead className="py-2 font-semibold">제목</TableHead>
+              <TableHead className="hidden py-2 font-semibold md:table-cell">
+                요약
+              </TableHead>
+              <TableHead className="hidden w-[100px] py-2 font-semibold sm:table-cell">
                 카테고리
               </TableHead>
-              <TableHead className="hidden w-[150px] lg:table-cell">
+              <TableHead className="hidden w-[150px] py-2 font-semibold lg:table-cell">
                 작성자
               </TableHead>
-              <TableHead className="hidden w-[150px] lg:table-cell">
+              <TableHead className="hidden w-[150px] py-2 font-semibold lg:table-cell">
                 작성일
               </TableHead>
-              <TableHead className="hidden w-[150px] xl:table-cell">
+              <TableHead className="hidden w-[150px] py-2 font-semibold xl:table-cell">
                 업데이트일
               </TableHead>
-              <TableHead className="hidden w-[100px] text-right sm:table-cell">
+              <TableHead className="hidden w-[100px] py-2 text-right font-semibold sm:table-cell">
                 조회
               </TableHead>
-              <TableHead className="w-[100px] text-right">좋아요</TableHead>
+              <TableHead className="w-[100px] py-2 text-right font-semibold">
+                좋아요
+              </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -100,21 +103,23 @@ export default function Posts() {
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() => handleRowClick(post.id)}
               >
-                <TableCell>
-                  <div>
-                    <span className="font-medium">{post.title}</span>
-                    <div className="mt-1 text-sm text-muted-foreground md:hidden">
-                      {post.excerpt}
+                <TableCell className="py-2">
+                  <div className="space-y-2">
+                    <span className="line-clamp-1 font-medium">
+                      {post.title}
+                    </span>
+                    <div className="text-sm text-muted-foreground md:hidden">
+                      <p className="line-clamp-1">{post.excerpt}</p>
                     </div>
-                    <div className="mt-1 text-sm text-muted-foreground lg:hidden">
+                    <div className="text-sm text-muted-foreground lg:hidden">
                       {post.authorId} · {formatDate(post.createdAt)}
                     </div>
                     {post.tags.length > 0 && (
-                      <div className="mt-1 flex flex-wrap gap-1">
+                      <div className="flex flex-wrap gap-1">
                         {post.tags.map((tag) => (
                           <span
                             key={tag}
-                            className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                            className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground hover:bg-muted/80"
                           >
                             {tag}
                           </span>
@@ -123,27 +128,29 @@ export default function Posts() {
                     )}
                   </div>
                 </TableCell>
-                <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                  {post.excerpt}
+                <TableCell className="hidden py-2 text-sm text-muted-foreground md:table-cell">
+                  <p className="line-clamp-1">{post.excerpt}</p>
                 </TableCell>
-                <TableCell className="hidden sm:table-cell">
-                  <span className="rounded-lg bg-primary/10 px-2 py-1 text-sm text-primary">
+                <TableCell className="hidden py-2 sm:table-cell">
+                  <span className="rounded-lg bg-blue-50 px-2 py-1 text-sm text-blue-600 transition-colors hover:bg-blue-100 dark:bg-blue-500/10 dark:text-blue-400 dark:hover:bg-blue-500/20">
                     {post.categoryId}
                   </span>
                 </TableCell>
-                <TableCell className="hidden lg:table-cell">
+                <TableCell className="hidden py-2 text-muted-foreground lg:table-cell">
                   {post.authorId}
                 </TableCell>
-                <TableCell className="hidden lg:table-cell">
+                <TableCell className="hidden py-2 text-muted-foreground lg:table-cell">
                   {formatDate(post.createdAt)}
                 </TableCell>
-                <TableCell className="hidden xl:table-cell">
+                <TableCell className="hidden py-2 text-muted-foreground xl:table-cell">
                   {formatDate(post.updatedAt)}
                 </TableCell>
-                <TableCell className="hidden text-right sm:table-cell">
+                <TableCell className="hidden py-2 text-right text-muted-foreground sm:table-cell">
                   {post.viewCount}
                 </TableCell>
-                <TableCell className="text-right">{post.likeCount}</TableCell>
+                <TableCell className="py-2 text-right font-medium">
+                  {post.likeCount}
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/src/routes/posts/PostsPage.tsx
+++ b/src/routes/posts/PostsPage.tsx
@@ -16,36 +16,31 @@ import {
 } from "@/components/ui/pagination";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-
-interface Post {
-  id: number;
-  title: string;
-  author: string;
-  createdAt: string;
-  updatedAt: string;
-  viewCount: number;
-  likeCount: number;
-  categoryId: number;
-  category: string;
-  tags: string[];
-  excerpt: string;
-}
+import { Post } from "@/types";
 
 const DUMMY_POSTS: Post[] = Array.from({ length: 23 }, (_, i) => ({
-  id: i + 1,
+  id: `post${i + 1}`,
   title: `게시글 제목 ${i + 1}`,
-  author: `작성자 ${i + 1}`,
-  createdAt: new Date(2024, 0, i + 1).toLocaleDateString(),
-  updatedAt: new Date(2024, 0, i + 2).toLocaleDateString(),
-  viewCount: Math.floor(Math.random() * 100),
-  likeCount: Math.floor(Math.random() * 50),
-  categoryId: Math.floor(Math.random() * 3) + 1,
-  category: ["개발", "AI", "일상"][Math.floor(Math.random() * 3)],
+  content: `게시글 ${i + 1}의 전체 내용입니다.`,
+  excerpt: `이것은 게시글 ${i + 1}의 요약입니다.`,
+  categoryId: `category${Math.floor(Math.random() * 3) + 1}`,
   tags: ["React", "TypeScript", "JavaScript"].slice(
     0,
     Math.floor(Math.random() * 3) + 1,
   ),
-  excerpt: `이것은 게시글 ${i + 1}의 요약입니다.`,
+  thumbnailUrl: `https://picsum.photos/seed/${i + 1}/200/300`,
+  viewCount: Math.floor(Math.random() * 100),
+  likeCount: Math.floor(Math.random() * 50),
+  createdAt: {
+    seconds: Math.floor(Date.now() / 1000) - i * 86400,
+    nanoseconds: 0,
+  },
+  updatedAt: {
+    seconds: Math.floor(Date.now() / 1000) - i * 43200,
+    nanoseconds: 0,
+  },
+  authorId: `user${Math.floor(Math.random() * 5) + 1}`,
+  published: true,
 }));
 
 export default function Posts() {
@@ -58,8 +53,16 @@ export default function Posts() {
   const currentPosts = DUMMY_POSTS.slice(indexOfFirstPost, indexOfLastPost);
   const totalPages = Math.ceil(DUMMY_POSTS.length / postsPerPage);
 
-  const handleRowClick = (postId: number) => {
+  const handleRowClick = (postId: string) => {
     navigate(`/posts/${postId}`);
+  };
+
+  const formatDate = (
+    timestamp: { seconds: number; nanoseconds: number } | undefined,
+  ) => {
+    return timestamp
+      ? new Date(timestamp.seconds * 1000).toLocaleDateString()
+      : "-";
   };
 
   return (
@@ -104,7 +107,7 @@ export default function Posts() {
                       {post.excerpt}
                     </div>
                     <div className="mt-1 text-sm text-muted-foreground lg:hidden">
-                      {post.author} · {post.createdAt}
+                      {post.authorId} · {formatDate(post.createdAt)}
                     </div>
                     {post.tags.length > 0 && (
                       <div className="mt-1 flex flex-wrap gap-1">
@@ -125,17 +128,17 @@ export default function Posts() {
                 </TableCell>
                 <TableCell className="hidden sm:table-cell">
                   <span className="rounded-lg bg-primary/10 px-2 py-1 text-sm text-primary">
-                    {post.category}
+                    {post.categoryId}
                   </span>
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
-                  {post.author}
+                  {post.authorId}
                 </TableCell>
                 <TableCell className="hidden lg:table-cell">
-                  {post.createdAt}
+                  {formatDate(post.createdAt)}
                 </TableCell>
                 <TableCell className="hidden xl:table-cell">
-                  {post.updatedAt}
+                  {formatDate(post.updatedAt)}
                 </TableCell>
                 <TableCell className="hidden text-right sm:table-cell">
                   {post.viewCount}


### PR DESCRIPTION
- shadcn/ui table, pagination 컴포넌트 사용
- 모바일 반응형에 따른 테이블 UI 구성 적용

<img width="1721" alt="스크린샷 2025-01-14 오전 12 11 35" src="https://github.com/user-attachments/assets/e9aaa793-46c3-40ea-a390-c9fbf514f954" />
