### PR TITLE
게시글 목록에 실 데이터 연동, 리액트 쿼리 사용, firestore onSnapshot 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-toast": "^1.2.4",
+    "@tanstack/react-query": "^5.64.1",
     "@toast-ui/editor": "^3.2.2",
     "@toast-ui/react-editor": "^3.2.3",
     "class-variance-authority": "^0.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,22 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./routes";
 import AuthProvider from "@/contexts/AuthProvider";
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000, // 1분
+    },
+  },
+});
+
 function App() {
   return (
     <AuthProvider>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </AuthProvider>
   );
 }

--- a/src/routes/posts/PostsPage.tsx
+++ b/src/routes/posts/PostsPage.tsx
@@ -1,3 +1,8 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { collection, getDocs, orderBy, query } from "firebase/firestore";
+
 import {
   Table,
   TableBody,
@@ -14,44 +19,33 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { Post } from "@/types";
-
-const DUMMY_POSTS: Post[] = Array.from({ length: 23 }, (_, i) => ({
-  id: `post${i + 1}`,
-  title: `게시글 제목 ${i + 1}`,
-  content: `게시글 ${i + 1}의 전체 내용입니다.`,
-  excerpt: `이것은 게시글 ${i + 1}의 요약입니다.`,
-  categoryId: `category${Math.floor(Math.random() * 3) + 1}`,
-  tags: ["React", "TypeScript", "JavaScript"].slice(
-    0,
-    Math.floor(Math.random() * 3) + 1,
-  ),
-  thumbnailUrl: `https://picsum.photos/seed/${i + 1}/200/300`,
-  viewCount: Math.floor(Math.random() * 100),
-  likeCount: Math.floor(Math.random() * 50),
-  createdAt: {
-    seconds: Math.floor(Date.now() / 1000) - i * 86400,
-    nanoseconds: 0,
-  },
-  updatedAt: {
-    seconds: Math.floor(Date.now() / 1000) - i * 43200,
-    nanoseconds: 0,
-  },
-  authorId: `user${Math.floor(Math.random() * 5) + 1}`,
-  published: true,
-}));
+import { db } from "@/lib/firebase/firebase";
+import { stripHtmlTags } from "@/utils";
 
 export default function Posts() {
   const [currentPage, setCurrentPage] = useState(1);
   const navigate = useNavigate();
   const postsPerPage = 10;
 
+  const { data: posts, isLoading } = useQuery({
+    queryKey: ["posts"],
+    queryFn: async () => {
+      const postsRef = collection(db, "posts");
+      const q = query(postsRef, orderBy("createdAt", "desc"));
+      const querySnapshot = await getDocs(q);
+
+      return querySnapshot.docs.map((doc) => ({
+        id: doc.id,
+        ...doc.data(),
+      })) as Post[];
+    },
+  });
+
   const indexOfLastPost = currentPage * postsPerPage;
   const indexOfFirstPost = indexOfLastPost - postsPerPage;
-  const currentPosts = DUMMY_POSTS.slice(indexOfFirstPost, indexOfLastPost);
-  const totalPages = Math.ceil(DUMMY_POSTS.length / postsPerPage);
+  const currentPosts = posts?.slice(indexOfFirstPost, indexOfLastPost) ?? [];
+  const totalPages = Math.ceil((posts?.length ?? 0) / postsPerPage);
 
   const handleRowClick = (postId: string) => {
     navigate(`/posts/${postId}`);
@@ -65,6 +59,16 @@ export default function Posts() {
       : "-";
   };
 
+  if (isLoading) {
+    return (
+      <div className="container">
+        <div className="flex h-[400px] items-center justify-center">
+          <div className="text-muted-foreground">로딩 중...</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="container">
       <h1 className="mb-8 text-3xl font-bold">게시글 목록</h1>
@@ -72,26 +76,28 @@ export default function Posts() {
         <Table>
           <TableHeader>
             <TableRow className="bg-muted/50 hover:bg-muted/50">
-              <TableHead className="py-2 font-semibold">제목</TableHead>
-              <TableHead className="hidden py-2 font-semibold md:table-cell">
+              <TableHead className="w-[360px] py-2 font-semibold">
+                제목
+              </TableHead>
+              <TableHead className="hidden w-[200px] py-2 font-semibold md:table-cell">
                 요약
               </TableHead>
               <TableHead className="hidden w-[100px] py-2 font-semibold sm:table-cell">
                 카테고리
               </TableHead>
-              <TableHead className="hidden w-[150px] py-2 font-semibold lg:table-cell">
+              <TableHead className="hidden w-[100px] py-2 font-semibold lg:table-cell">
                 작성자
               </TableHead>
-              <TableHead className="hidden w-[150px] py-2 font-semibold lg:table-cell">
+              <TableHead className="hidden w-[100px] py-2 font-semibold lg:table-cell">
                 작성일
               </TableHead>
-              <TableHead className="hidden w-[150px] py-2 font-semibold xl:table-cell">
+              <TableHead className="hidden w-[100px] py-2 font-semibold xl:table-cell">
                 업데이트일
               </TableHead>
-              <TableHead className="hidden w-[100px] py-2 text-right font-semibold sm:table-cell">
+              <TableHead className="hidden w-[80px] py-2 text-right font-semibold sm:table-cell">
                 조회
               </TableHead>
-              <TableHead className="w-[100px] py-2 text-right font-semibold">
+              <TableHead className="w-[80px] min-w-[80px] py-2 text-right font-semibold">
                 좋아요
               </TableHead>
             </TableRow>
@@ -103,16 +109,18 @@ export default function Posts() {
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() => handleRowClick(post.id)}
               >
-                <TableCell className="py-2">
+                <TableCell className="w-[360px] py-2">
                   <div className="space-y-2">
                     <span className="line-clamp-1 font-medium">
                       {post.title}
                     </span>
                     <div className="text-sm text-muted-foreground md:hidden">
-                      <p className="line-clamp-1">{post.excerpt}</p>
+                      <p className="line-clamp-1">
+                        {stripHtmlTags(post.excerpt)}
+                      </p>
                     </div>
                     <div className="text-sm text-muted-foreground lg:hidden">
-                      {post.authorId} · {formatDate(post.createdAt)}
+                      도토리묵 · {formatDate(post.createdAt)}
                     </div>
                     {post.tags.length > 0 && (
                       <div className="flex flex-wrap gap-1">
@@ -128,27 +136,27 @@ export default function Posts() {
                     )}
                   </div>
                 </TableCell>
-                <TableCell className="hidden py-2 text-sm text-muted-foreground md:table-cell">
-                  <p className="line-clamp-1">{post.excerpt}</p>
+                <TableCell className="hidden w-[200px] py-2 text-sm text-muted-foreground md:table-cell">
+                  <p className="line-clamp-1">{stripHtmlTags(post.excerpt)}</p>
                 </TableCell>
-                <TableCell className="hidden py-2 sm:table-cell">
-                  <span className="rounded-lg bg-blue-50 px-2 py-1 text-sm text-blue-600 transition-colors hover:bg-blue-100 dark:bg-blue-500/10 dark:text-blue-400 dark:hover:bg-blue-500/20">
+                <TableCell className="hidden w-[100px] py-2 sm:table-cell">
+                  <span className="rounded-lg bg-primary/5 px-2 py-1 text-sm text-primary transition-colors hover:bg-primary/10">
                     {post.categoryId}
                   </span>
                 </TableCell>
-                <TableCell className="hidden py-2 text-muted-foreground lg:table-cell">
-                  {post.authorId}
+                <TableCell className="hidden w-[100px] py-2 text-muted-foreground lg:table-cell">
+                  도토리묵
                 </TableCell>
-                <TableCell className="hidden py-2 text-muted-foreground lg:table-cell">
+                <TableCell className="hidden w-[100px] py-2 text-muted-foreground lg:table-cell">
                   {formatDate(post.createdAt)}
                 </TableCell>
-                <TableCell className="hidden py-2 text-muted-foreground xl:table-cell">
+                <TableCell className="hidden w-[100px] py-2 text-muted-foreground xl:table-cell">
                   {formatDate(post.updatedAt)}
                 </TableCell>
-                <TableCell className="hidden py-2 text-right text-muted-foreground sm:table-cell">
+                <TableCell className="hidden w-[80px] py-2 text-right text-muted-foreground sm:table-cell">
                   {post.viewCount}
                 </TableCell>
-                <TableCell className="py-2 text-right font-medium">
+                <TableCell className="w-[80px] min-w-[80px] py-2 text-right font-medium">
                   {post.likeCount}
                 </TableCell>
               </TableRow>

--- a/src/routes/posts/PostsPage.tsx
+++ b/src/routes/posts/PostsPage.tsx
@@ -28,6 +28,7 @@ import {
 import { Post } from "@/types";
 import { db } from "@/lib/firebase/firebase";
 import { stripHtmlTags } from "@/utils";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function Posts() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -87,8 +88,74 @@ export default function Posts() {
   if (isLoading) {
     return (
       <div className="container">
-        <div className="flex h-[400px] items-center justify-center">
-          <div className="text-muted-foreground">로딩 중...</div>
+        <h1 className="mb-8 text-3xl font-bold">게시글 목록</h1>
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-muted/50 hover:bg-muted/50">
+                <TableHead className="w-[360px] py-2 font-semibold">
+                  제목
+                </TableHead>
+                <TableHead className="hidden w-[200px] py-2 font-semibold md:table-cell">
+                  요약
+                </TableHead>
+                <TableHead className="hidden w-[100px] py-2 font-semibold sm:table-cell">
+                  카테고리
+                </TableHead>
+                <TableHead className="hidden w-[100px] py-2 font-semibold lg:table-cell">
+                  작성자
+                </TableHead>
+                <TableHead className="hidden w-[100px] py-2 font-semibold lg:table-cell">
+                  작성일
+                </TableHead>
+                <TableHead className="hidden w-[100px] py-2 font-semibold xl:table-cell">
+                  업데이트일
+                </TableHead>
+                <TableHead className="hidden w-[80px] py-2 text-right font-semibold sm:table-cell">
+                  조회
+                </TableHead>
+                <TableHead className="w-[80px] min-w-[80px] py-2 text-right font-semibold">
+                  좋아요
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {Array.from({ length: 10 }).map((_, index) => (
+                <TableRow key={index}>
+                  <TableCell className="w-[360px] py-2">
+                    <div className="space-y-2">
+                      <Skeleton className="h-4 w-3/4" />
+                      <div className="flex gap-1">
+                        <Skeleton className="h-3 w-12" />
+                        <Skeleton className="h-3 w-12" />
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell className="hidden w-[200px] py-2 md:table-cell">
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                  <TableCell className="hidden w-[100px] py-2 sm:table-cell">
+                    <Skeleton className="h-4 w-16" />
+                  </TableCell>
+                  <TableCell className="hidden w-[100px] py-2 lg:table-cell">
+                    <Skeleton className="h-4 w-16" />
+                  </TableCell>
+                  <TableCell className="hidden w-[100px] py-2 lg:table-cell">
+                    <Skeleton className="h-4 w-20" />
+                  </TableCell>
+                  <TableCell className="hidden w-[100px] py-2 xl:table-cell">
+                    <Skeleton className="h-4 w-20" />
+                  </TableCell>
+                  <TableCell className="hidden w-[80px] py-2 text-right sm:table-cell">
+                    <Skeleton className="ml-auto h-4 w-8" />
+                  </TableCell>
+                  <TableCell className="w-[80px] min-w-[80px] py-2 text-right">
+                    <Skeleton className="ml-auto h-4 w-8" />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </div>
       </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,6 +1296,18 @@
     lodash.merge "^4.6.2"
     postcss-selector-parser "6.0.10"
 
+"@tanstack/query-core@5.64.1":
+  version "5.64.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.64.1.tgz#d56e26b3e29fc68a89d140f1fd92900bc8f3fc86"
+  integrity sha512-978Wx4Wl4UJZbmvU/rkaM9cQtXXrbhK0lsz/UZhYIbyKYA8E4LdomTwyh2GHZ4oU0BKKoDH4YlKk2VscCUgNmg==
+
+"@tanstack/react-query@^5.64.1":
+  version "5.64.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.64.1.tgz#46b4182f5b045299e4be8d0a91c549ac5dc0a20c"
+  integrity sha512-vW5ggHpIO2Yjj44b4sB+Fd3cdnlMJppXRBJkEHvld6FXh3j5dwWJoQo7mGtKI2RbSFyiyu/PhGAy0+Vv5ev9Eg==
+  dependencies:
+    "@tanstack/query-core" "5.64.1"
+
 "@toast-ui/editor@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@toast-ui/editor/-/editor-3.2.2.tgz#1f2837271c5c9c3e29e090d7440bfc6ab23fb4c4"


### PR DESCRIPTION
<img width="1721" alt="스크린샷 2025-01-14 오전 12 48 44" src="https://github.com/user-attachments/assets/b5a141f8-61f0-4e13-a7be-f3bcbc2dfddb" />

- 게시글 목록에 실 데이터 연동
- tanstack-react-query 설치 및 적용
- Firestore의 onSnapshot을 사용하여 게시글 목록의 실시간 업데이트 기능 구현