### PR TITLE
fix: update default thumbnail import for production build

### DIFF
--- a/src/components/home/PopularPosts.tsx
+++ b/src/components/home/PopularPosts.tsx
@@ -1,4 +1,6 @@
 import { Link } from "react-router-dom";
+import { Timestamp } from "firebase/firestore";
+import { FileText } from "lucide-react";
 import {
   Carousel,
   CarouselContent,
@@ -11,15 +13,15 @@ import { Card, CardContent } from "@/components/ui/card";
 import PostCardSkeleton from "../common/PostCardSkeleton";
 import { stripHtmlTags } from "@/utils";
 import { Post } from "@/types";
-import { Timestamp } from "firebase/firestore";
-import { FileText } from "lucide-react";
+
+import defaultThumbnail from "@/assets/default-thumbnail.jpg";
 
 interface PopularPostsProps {
   posts: Post[];
   isLoading: boolean;
 }
 
-const DEFAULT_THUMBNAIL = "/src/assets/default-thumbnail.jpg";
+const DEFAULT_THUMBNAIL = defaultThumbnail;
 
 export function PopularPosts({ posts, isLoading }: PopularPostsProps) {
   if (isLoading) {

--- a/src/components/home/RecentPosts.tsx
+++ b/src/components/home/RecentPosts.tsx
@@ -7,12 +7,14 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Post } from "@/types";
 import { stripHtmlTags } from "@/utils";
 import PostCardSkeleton from "../common/PostCardSkeleton";
+import defaultThumbnail from "@/assets/default-thumbnail.jpg";
+
 interface RecentPostsProps {
   posts: Post[];
   isLoading: boolean;
 }
 
-const DEFAULT_THUMBNAIL = "/src/assets/default-thumbnail.jpg";
+const DEFAULT_THUMBNAIL = defaultThumbnail;
 
 export function RecentPosts({ posts, isLoading }: RecentPostsProps) {
   const navigate = useNavigate();


### PR DESCRIPTION
- 블로그 게시글의 기본 썸네일이 없을 때 보여줄 썸네일 경로 수정
